### PR TITLE
Fix linting of xsd files

### DIFF
--- a/base_ubl/data/xsd-2.2/common/CCTS_CCT_SchemaModule-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/CCTS_CCT_SchemaModule-2.2.xsd
@@ -7,9 +7,9 @@
    Agency: UN/CEFACT
    VersionID: 1.1
    Last change: 14 January 2005
-   
-   
-   
+
+
+
    Copyright (C) UN/CEFACT (2006). All Rights Reserved.
    This document and translations of it may be copied and furnished to others,
    and derivative works that comment on or otherwise explain it or assist
@@ -21,13 +21,13 @@
    UN/CEFACT, except as needed for the purpose of developing UN/CEFACT
    specifications, in which case the procedures for copyrights defined in the
    UN/CEFACT Intellectual Property Rights document must be followed, or as
-   
-   
+
+
    required to translate it into languages other than English.
    The limited permissions granted above are perpetual and will not be revoked
-   
-   
-   
+
+
+
    by UN/CEFACT or its successors or assigns.
    This document and the information contained herein is provided on an "AS IS"
    basis and UN/CEFACT DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING

--- a/base_ubl/data/xsd-2.2/common/UBL-CommonAggregateComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-CommonAggregateComponents-2.2.xsd
@@ -43493,48 +43493,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-CommonBasicComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-CommonBasicComponents-2.2.xsd
@@ -5960,48 +5960,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-CommonExtensionComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-CommonExtensionComponents-2.2.xsd
@@ -7,12 +7,12 @@
   Generated on:      2017-01-02 17:20(UTC)
   Copyright (c) OASIS Open 2017. All Rights Reserved.
 -->
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+xmlns="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
 xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
-targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" 
-            elementFormDefault="qualified" attributeFormDefault="unqualified" 
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+            elementFormDefault="qualified" attributeFormDefault="unqualified"
             version="2.2">
 <!-- ===== Imports ===== -->
   <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
@@ -178,48 +178,48 @@ targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionCom
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
   PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-CommonSignatureComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-CommonSignatureComponents-2.2.xsd
@@ -55,48 +55,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-ExtensionContentDataType-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-ExtensionContentDataType-2.2.xsd
@@ -6,7 +6,7 @@
   Module:            UBL-ExtensionContentDataType-2.2.xsd
   Generated on:      2016-06-24 19:50(UTC)
   Copyright (c) OASIS Open 2016. All Rights Reserved.
-  
+
   Release Note: This is a module that can be modified by users, typically
   only to add extension schema fragments for lax detection when encountered.
   Changes to the complex type should not be required for typical use.
@@ -15,12 +15,12 @@
      "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
             targetNamespace=
      "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
-            elementFormDefault="qualified" 
-            attributeFormDefault="unqualified" 
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
             version="2.2">
 
   <!-- ===== import here all extension schemas ===== -->
-  
+
   <!-- UBL Technical Committee extensions -->
   <xsd:import namespace=
      "urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2"
@@ -54,48 +54,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
   PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-QualifiedDataTypes-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-QualifiedDataTypes-2.2.xsd
@@ -122,48 +122,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-SignatureAggregateComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-SignatureAggregateComponents-2.2.xsd
@@ -28,7 +28,7 @@
    <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
                schemaLocation="UBL-xmldsig1-schema-2.2.xsd"/>
 
-          
+
    <!-- ===== Element Declarations ===== -->
    <xsd:element name="SignatureInformation" type="SignatureInformationType"/>
    <!-- ===== Type Definitions ===== -->
@@ -87,48 +87,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-SignatureBasicComponents-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-SignatureBasicComponents-2.2.xsd
@@ -32,48 +32,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-UnqualifiedDataTypes-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-UnqualifiedDataTypes-2.2.xsd
@@ -18,12 +18,12 @@
   Per table 8-3, the value, rate and percentage types are based on
   "Numeric. Type" as they are secondary representation terms.
 
-  Per table 8-3, the name type is based on "Text. Type" as it is a 
+  Per table 8-3, the name type is based on "Text. Type" as it is a
   secondary representation term.
 
-  Per XSD lexical constraints, the following unqualified data types 
-  corresponding to core component types and secondary representation terms 
-  are based on XSD types (accordingly, the supplementary component "format" 
+  Per XSD lexical constraints, the following unqualified data types
+  corresponding to core component types and secondary representation terms
+  are based on XSD types (accordingly, the supplementary component "format"
   is not made available for these types):
 
         Date Time. Type  on  xsd:dateTime
@@ -45,11 +45,11 @@
   All other unqualified data types inherit the core component types complete
   with their supplementary components.
 -->
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" 
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+targetNamespace="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2"
 xmlns:ccts-cct="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2"
-            xmlns:ccts="urn:un:unece:uncefact:documentation:2" 
-            elementFormDefault="qualified" 
+            xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+            elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="2.1">
 <!-- ===== Imports ===== -->
@@ -265,7 +265,7 @@ namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModul
       <xsd:extension base="ccts-cct:CodeType"/>
     </xsd:simpleContent>
   </xsd:complexType>
-  
+
   <xsd:complexType name="DateTimeType">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
@@ -386,7 +386,7 @@ namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModul
       </xsd:restriction>
     </xsd:simpleContent>
   </xsd:complexType>
-  
+
   <xsd:complexType name="NumericType">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
@@ -506,48 +506,48 @@ namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModul
     </xsd:simpleContent>
   </xsd:complexType>
 </xsd:schema><!-- ===== Copyright Notice ===== --><!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
   PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/common/UBL-XAdES01903v132-201601-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-XAdES01903v132-201601-2.2.xsd
@@ -11,7 +11,7 @@
 -->
 <xsd:schema targetNamespace="http://uri.etsi.org/01903/v1.3.2#" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://uri.etsi.org/01903/v1.3.2#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified">
 	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="UBL-xmldsig-core-schema-2.2.xsd"/>
-	<!-- Start auxiliary types definitions: AnyType, ObjectIdentifierType, 
+	<!-- Start auxiliary types definitions: AnyType, ObjectIdentifierType,
 EncapsulatedPKIDataType and containers for time-stamp tokens -->
 	<!-- Start AnyType -->
 	<xsd:element name="Any" type="AnyType"/>

--- a/base_ubl/data/xsd-2.2/common/UBL-XAdES01903v141-201601-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-XAdES01903v141-201601-2.2.xsd
@@ -58,7 +58,7 @@
 	<!-- End RenewedDigests-->
 	<!-- -->
 	<!-- ArchiveTimeStamp in namespace with URI 'http://uri.etsi.org/01903/v1.4.1#'-->
-	<xsd:element name="ArchiveTimeStamp" type="xades:XAdESTimeStampType"/>	
+	<xsd:element name="ArchiveTimeStamp" type="xades:XAdESTimeStampType"/>
 	<!--CompleteCertificateRefsV2 and AttributeCertificateRefsV2-->
 	<xsd:element name="CompleteCertificateRefsV2" type="CompleteCertificateRefsTypeV2"/>
 	<xsd:element name="AttributeCertificateRefsV2" type="CompleteCertificateRefsTypeV2"/>

--- a/base_ubl/data/xsd-2.2/common/UBL-xmldsig-core-schema-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-xmldsig-core-schema-2.2.xsd
@@ -14,7 +14,7 @@
 <!DOCTYPE schema
   PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
  [
-   <!ATTLIST schema 
+   <!ATTLIST schema
      xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
    <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
    <!ENTITY % p ''>
@@ -42,7 +42,7 @@
 <schema xmlns="http://www.w3.org/2001/XMLSchema"
         xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
         targetNamespace="http://www.w3.org/2000/09/xmldsig#"
-        version="0.1" elementFormDefault="qualified"> 
+        version="0.1" elementFormDefault="qualified">
 
 <!-- Basic Types Defined for Signatures -->
 
@@ -55,16 +55,16 @@
 
 <element name="Signature" type="ds:SignatureType"/>
 <complexType name="SignatureType">
-  <sequence> 
-    <element ref="ds:SignedInfo"/> 
-    <element ref="ds:SignatureValue"/> 
-    <element ref="ds:KeyInfo" minOccurs="0"/> 
-    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
-  </sequence>  
+  <sequence>
+    <element ref="ds:SignedInfo"/>
+    <element ref="ds:SignatureValue"/>
+    <element ref="ds:KeyInfo" minOccurs="0"/>
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
   <attribute name="Id" type="ID" use="optional"/>
 </complexType>
 
-  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <element name="SignatureValue" type="ds:SignatureValueType"/>
   <complexType name="SignatureValueType">
     <simpleContent>
       <extension base="base64Binary">
@@ -77,21 +77,21 @@
 
 <element name="SignedInfo" type="ds:SignedInfoType"/>
 <complexType name="SignedInfoType">
-  <sequence> 
-    <element ref="ds:CanonicalizationMethod"/> 
-    <element ref="ds:SignatureMethod"/> 
-    <element ref="ds:Reference" maxOccurs="unbounded"/> 
-  </sequence>  
-  <attribute name="Id" type="ID" use="optional"/> 
+  <sequence>
+    <element ref="ds:CanonicalizationMethod"/>
+    <element ref="ds:SignatureMethod"/>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
 </complexType>
 
-  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/>
   <complexType name="CanonicalizationMethodType" mixed="true">
     <sequence>
       <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
       <!-- (0,unbounded) elements from (1,1) namespace -->
     </sequence>
-    <attribute name="Algorithm" type="anyURI" use="required"/> 
+    <attribute name="Algorithm" type="anyURI" use="required"/>
   </complexType>
 
   <element name="SignatureMethod" type="ds:SignatureMethodType"/>
@@ -101,48 +101,48 @@
       <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
       <!-- (0,unbounded) elements from (1,1) external namespace -->
     </sequence>
-    <attribute name="Algorithm" type="anyURI" use="required"/> 
+    <attribute name="Algorithm" type="anyURI" use="required"/>
   </complexType>
 
 <!-- Start Reference -->
 
 <element name="Reference" type="ds:ReferenceType"/>
 <complexType name="ReferenceType">
-  <sequence> 
-    <element ref="ds:Transforms" minOccurs="0"/> 
-    <element ref="ds:DigestMethod"/> 
-    <element ref="ds:DigestValue"/> 
+  <sequence>
+    <element ref="ds:Transforms" minOccurs="0"/>
+    <element ref="ds:DigestMethod"/>
+    <element ref="ds:DigestValue"/>
   </sequence>
-  <attribute name="Id" type="ID" use="optional"/> 
-  <attribute name="URI" type="anyURI" use="optional"/> 
-  <attribute name="Type" type="anyURI" use="optional"/> 
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="URI" type="anyURI" use="optional"/>
+  <attribute name="Type" type="anyURI" use="optional"/>
 </complexType>
 
   <element name="Transforms" type="ds:TransformsType"/>
   <complexType name="TransformsType">
     <sequence>
-      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+      <element ref="ds:Transform" maxOccurs="unbounded"/>
     </sequence>
   </complexType>
 
   <element name="Transform" type="ds:TransformType"/>
   <complexType name="TransformType" mixed="true">
-    <choice minOccurs="0" maxOccurs="unbounded"> 
+    <choice minOccurs="0" maxOccurs="unbounded">
       <any namespace="##other" processContents="lax"/>
       <!-- (1,1) elements from (0,unbounded) namespaces -->
-      <element name="XPath" type="string"/> 
+      <element name="XPath" type="string"/>
     </choice>
-    <attribute name="Algorithm" type="anyURI" use="required"/> 
+    <attribute name="Algorithm" type="anyURI" use="required"/>
   </complexType>
 
 <!-- End Reference -->
 
 <element name="DigestMethod" type="ds:DigestMethodType"/>
-<complexType name="DigestMethodType" mixed="true"> 
+<complexType name="DigestMethodType" mixed="true">
   <sequence>
     <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-  </sequence>    
-  <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </sequence>
+  <attribute name="Algorithm" type="anyURI" use="required"/>
 </complexType>
 
 <element name="DigestValue" type="ds:DigestValueType"/>
@@ -154,26 +154,26 @@
 
 <!-- Start KeyInfo -->
 
-<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<element name="KeyInfo" type="ds:KeyInfoType"/>
 <complexType name="KeyInfoType" mixed="true">
-  <choice maxOccurs="unbounded">     
-    <element ref="ds:KeyName"/> 
-    <element ref="ds:KeyValue"/> 
-    <element ref="ds:RetrievalMethod"/> 
-    <element ref="ds:X509Data"/> 
-    <element ref="ds:PGPData"/> 
+  <choice maxOccurs="unbounded">
+    <element ref="ds:KeyName"/>
+    <element ref="ds:KeyValue"/>
+    <element ref="ds:RetrievalMethod"/>
+    <element ref="ds:X509Data"/>
+    <element ref="ds:PGPData"/>
     <element ref="ds:SPKIData"/>
     <element ref="ds:MgmtData"/>
     <any processContents="lax" namespace="##other"/>
     <!-- (1,1) elements from (0,unbounded) namespaces -->
   </choice>
-  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="Id" type="ID" use="optional"/>
 </complexType>
 
   <element name="KeyName" type="string"/>
   <element name="MgmtData" type="string"/>
 
-  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <element name="KeyValue" type="ds:KeyValueType"/>
   <complexType name="KeyValueType" mixed="true">
    <choice>
      <element ref="ds:DSAKeyValue"/>
@@ -182,18 +182,18 @@
    </choice>
   </complexType>
 
-  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/>
   <complexType name="RetrievalMethodType">
     <sequence>
-      <element ref="ds:Transforms" minOccurs="0"/> 
-    </sequence>  
+      <element ref="ds:Transforms" minOccurs="0"/>
+    </sequence>
     <attribute name="URI" type="anyURI"/>
     <attribute name="Type" type="anyURI" use="optional"/>
   </complexType>
 
 <!-- Start X509Data -->
 
-<element name="X509Data" type="ds:X509DataType"/> 
+<element name="X509Data" type="ds:X509DataType"/>
 <complexType name="X509DataType">
   <sequence maxOccurs="unbounded">
     <choice>
@@ -207,10 +207,10 @@
   </sequence>
 </complexType>
 
-<complexType name="X509IssuerSerialType"> 
-  <sequence> 
-    <element name="X509IssuerName" type="string"/> 
-    <element name="X509SerialNumber" type="integer"/> 
+<complexType name="X509IssuerSerialType">
+  <sequence>
+    <element name="X509IssuerName" type="string"/>
+    <element name="X509SerialNumber" type="integer"/>
   </sequence>
 </complexType>
 
@@ -218,17 +218,17 @@
 
 <!-- Begin PGPData -->
 
-<element name="PGPData" type="ds:PGPDataType"/> 
-<complexType name="PGPDataType"> 
+<element name="PGPData" type="ds:PGPDataType"/>
+<complexType name="PGPDataType">
   <choice>
     <sequence>
-      <element name="PGPKeyID" type="base64Binary"/> 
-      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <element name="PGPKeyID" type="base64Binary"/>
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/>
       <any namespace="##other" processContents="lax" minOccurs="0"
        maxOccurs="unbounded"/>
     </sequence>
     <sequence>
-      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary"/>
       <any namespace="##other" processContents="lax" minOccurs="0"
        maxOccurs="unbounded"/>
     </sequence>
@@ -239,13 +239,13 @@
 
 <!-- Begin SPKIData -->
 
-<element name="SPKIData" type="ds:SPKIDataType"/> 
+<element name="SPKIData" type="ds:SPKIDataType"/>
 <complexType name="SPKIDataType">
   <sequence maxOccurs="unbounded">
     <element name="SPKISexp" type="base64Binary"/>
     <any namespace="##other" processContents="lax" minOccurs="0"/>
   </sequence>
-</complexType> 
+</complexType>
 
 <!-- End SPKIData -->
 
@@ -253,40 +253,40 @@
 
 <!-- Start Object (Manifest, SignatureProperty) -->
 
-<element name="Object" type="ds:ObjectType"/> 
+<element name="Object" type="ds:ObjectType"/>
 <complexType name="ObjectType" mixed="true">
   <sequence minOccurs="0" maxOccurs="unbounded">
     <any namespace="##any" processContents="lax"/>
   </sequence>
-  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="Id" type="ID" use="optional"/>
   <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
-  <attribute name="Encoding" type="anyURI" use="optional"/> 
+  <attribute name="Encoding" type="anyURI" use="optional"/>
 </complexType>
 
-<element name="Manifest" type="ds:ManifestType"/> 
+<element name="Manifest" type="ds:ManifestType"/>
 <complexType name="ManifestType">
   <sequence>
-    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
   </sequence>
-  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="Id" type="ID" use="optional"/>
 </complexType>
 
-<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/>
 <complexType name="SignaturePropertiesType">
   <sequence>
-    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/>
   </sequence>
-  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="Id" type="ID" use="optional"/>
 </complexType>
 
-   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/>
    <complexType name="SignaturePropertyType" mixed="true">
      <choice maxOccurs="unbounded">
        <any namespace="##other" processContents="lax"/>
        <!-- (1,1) elements from (1,unbounded) namespaces -->
      </choice>
-     <attribute name="Target" type="anyURI" use="required"/> 
-     <attribute name="Id" type="ID" use="optional"/> 
+     <attribute name="Target" type="anyURI" use="required"/>
+     <attribute name="Id" type="ID" use="optional"/>
    </complexType>
 
 <!-- End Object (Manifest, SignatureProperty) -->
@@ -319,10 +319,10 @@
 <element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
 <complexType name="RSAKeyValueType">
   <sequence>
-    <element name="Modulus" type="ds:CryptoBinary"/> 
-    <element name="Exponent" type="ds:CryptoBinary"/> 
+    <element name="Modulus" type="ds:CryptoBinary"/>
+    <element name="Exponent" type="ds:CryptoBinary"/>
   </sequence>
-</complexType> 
+</complexType>
 
 <!-- End KeyValue Element-types -->
 

--- a/base_ubl/data/xsd-2.2/common/UBL-xmldsig1-schema-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-xmldsig1-schema-2.2.xsd
@@ -5,7 +5,7 @@
   Release Date:      09 July 2018
   Module:            UBL-xmldsig1-schema-2.2.xsd
   Generated on:      2016-06-24 19:50(UTC)
- 
+
   This is a copy of http://www.w3.org/TR/xmldsig-core1/xmldsig1-schema.xsd
   changed only to correctly import the local copies of the included and
   imported schema fragments.
@@ -13,14 +13,14 @@
 
 <!--
 #
-# Copyright ©[2011] World Wide Web Consortium 
-# (Massachusetts Institute of Technology,  
-#  European Research Consortium for Informatics and Mathematics, 
-#  Keio University). All Rights Reserved.  
+# Copyright ©[2011] World Wide Web Consortium
+# (Massachusetts Institute of Technology,
+#  European Research Consortium for Informatics and Mathematics,
+#  Keio University). All Rights Reserved.
 # This work is distributed under the W3C® Software License [1] in the
 # hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 # the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. 
+# PURPOSE.
 # [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 -->
@@ -35,4 +35,3 @@
   <import namespace="http://www.w3.org/2009/xmldsig11#"
    schemaLocation="UBL-xmldsig11-schema-2.2.xsd"/>
 </schema>
-

--- a/base_ubl/data/xsd-2.2/common/UBL-xmldsig11-schema-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/common/UBL-xmldsig11-schema-2.2.xsd
@@ -5,21 +5,21 @@
   Release Date:      09 July 2018
   Module:            UBL-xmldsig11-schema-2.2.xsd
   Generated on:      2016-06-24 19:50(UTC)
- 
+
   This is a copy of http://www.w3.org/TR/xmldsig-core1/xmldsig11-schema.xsd
   changed only to include this header information.
 -->
 
 <!--
 #
-# Copyright ©[2011] World Wide Web Consortium 
-# (Massachusetts Institute of Technology,  
-#  European Research Consortium for Informatics and Mathematics, 
-#  Keio University). All Rights Reserved.  
+# Copyright ©[2011] World Wide Web Consortium
+# (Massachusetts Institute of Technology,
+#  European Research Consortium for Informatics and Mathematics,
+#  Keio University). All Rights Reserved.
 # This work is distributed under the W3C® Software License [1] in the
 # hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 # the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-# PURPOSE. 
+# PURPOSE.
 # [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
 #
 -->
@@ -47,7 +47,7 @@
   <complexType name="NamedCurveType">
     <attribute name="URI" type="anyURI" use="required"/>
   </complexType>
-  
+
   <simpleType name="ECPointType">
     <restriction base="ds:CryptoBinary"/>
   </simpleType>
@@ -63,7 +63,7 @@
                type="dsig11:ECValidationDataType" minOccurs="0"/>
     </sequence>
   </complexType>
-  
+
   <complexType name="FieldIDType">
     <choice>
       <element ref="dsig11:Prime"/>
@@ -101,7 +101,7 @@
       <element name="M" type="positiveInteger"/>
     </sequence>
   </complexType>
-  
+
   <element name="TnB" type="dsig11:TnBFieldParamsType"/>
   <complexType name="TnBFieldParamsType">
     <complexContent>
@@ -135,7 +135,7 @@
     </simpleContent>
   </complexType>
 
-  <element name="KeyInfoReference" type="dsig11:KeyInfoReferenceType"/> 
+  <element name="KeyInfoReference" type="dsig11:KeyInfoReferenceType"/>
   <complexType name="KeyInfoReferenceType">
     <attribute name="URI" type="anyURI" use="required"/>
     <attribute name="Id" type="ID" use="optional"/>
@@ -151,4 +151,3 @@
   </complexType>
 
 </schema>
-

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ApplicationResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ApplicationResponse-2.2.xsd
@@ -316,48 +316,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-AttachedDocument-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-AttachedDocument-2.2.xsd
@@ -370,48 +370,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-AwardedNotification-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-AwardedNotification-2.2.xsd
@@ -372,48 +372,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-BillOfLading-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-BillOfLading-2.2.xsd
@@ -494,48 +494,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-BusinessCard-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-BusinessCard-2.2.xsd
@@ -359,48 +359,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CallForTenders-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CallForTenders-2.2.xsd
@@ -505,48 +505,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Catalogue-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Catalogue-2.2.xsd
@@ -519,48 +519,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueDeletion-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueDeletion-2.2.xsd
@@ -419,48 +419,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueItemSpecificationUpdate-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueItemSpecificationUpdate-2.2.xsd
@@ -487,48 +487,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CataloguePricingUpdate-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CataloguePricingUpdate-2.2.xsd
@@ -486,48 +486,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CatalogueRequest-2.2.xsd
@@ -525,48 +525,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CertificateOfOrigin-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CertificateOfOrigin-2.2.xsd
@@ -371,48 +371,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ContractAwardNotice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ContractAwardNotice-2.2.xsd
@@ -465,48 +465,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ContractNotice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ContractNotice-2.2.xsd
@@ -447,48 +447,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-CreditNote-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-CreditNote-2.2.xsd
@@ -954,48 +954,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DebitNote-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DebitNote-2.2.xsd
@@ -887,48 +887,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DespatchAdvice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DespatchAdvice-2.2.xsd
@@ -436,48 +436,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DigitalAgreement-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DigitalAgreement-2.2.xsd
@@ -375,48 +375,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DigitalCapability-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DigitalCapability-2.2.xsd
@@ -303,48 +303,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DocumentStatus-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DocumentStatus-2.2.xsd
@@ -304,48 +304,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-DocumentStatusRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-DocumentStatusRequest-2.2.xsd
@@ -302,48 +302,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Enquiry-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Enquiry-2.2.xsd
@@ -338,48 +338,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-EnquiryResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-EnquiryResponse-2.2.xsd
@@ -321,48 +321,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ExceptionCriteria-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ExceptionCriteria-2.2.xsd
@@ -371,48 +371,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ExceptionNotification-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ExceptionNotification-2.2.xsd
@@ -357,48 +357,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ExpressionOfInterestRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ExpressionOfInterestRequest-2.2.xsd
@@ -381,48 +381,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ExpressionOfInterestResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ExpressionOfInterestResponse-2.2.xsd
@@ -367,48 +367,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Forecast-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Forecast-2.2.xsd
@@ -408,48 +408,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ForecastRevision-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ForecastRevision-2.2.xsd
@@ -407,48 +407,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ForwardingInstructions-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ForwardingInstructions-2.2.xsd
@@ -487,48 +487,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-FreightInvoice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-FreightInvoice-2.2.xsd
@@ -870,48 +870,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-FulfilmentCancellation-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-FulfilmentCancellation-2.2.xsd
@@ -425,48 +425,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-GoodsItemItinerary-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-GoodsItemItinerary-2.2.xsd
@@ -385,48 +385,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-GuaranteeCertificate-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-GuaranteeCertificate-2.2.xsd
@@ -435,48 +435,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-InstructionForReturns-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-InstructionForReturns-2.2.xsd
@@ -337,48 +337,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-InventoryReport-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-InventoryReport-2.2.xsd
@@ -355,48 +355,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Invoice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Invoice-2.2.xsd
@@ -956,48 +956,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ItemInformationRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ItemInformationRequest-2.2.xsd
@@ -356,48 +356,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Order-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Order-2.2.xsd
@@ -845,48 +845,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-OrderCancellation-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-OrderCancellation-2.2.xsd
@@ -370,48 +370,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-OrderChange-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-OrderChange-2.2.xsd
@@ -823,48 +823,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-OrderResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-OrderResponse-2.2.xsd
@@ -929,48 +929,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-OrderResponseSimple-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-OrderResponseSimple-2.2.xsd
@@ -459,48 +459,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-PackingList-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-PackingList-2.2.xsd
@@ -386,48 +386,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-PriorInformationNotice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-PriorInformationNotice-2.2.xsd
@@ -429,48 +429,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ProductActivity-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ProductActivity-2.2.xsd
@@ -341,48 +341,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-QualificationApplicationRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-QualificationApplicationRequest-2.2.xsd
@@ -473,48 +473,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-QualificationApplicationResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-QualificationApplicationResponse-2.2.xsd
@@ -523,48 +523,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Quotation-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Quotation-2.2.xsd
@@ -537,48 +537,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-ReceiptAdvice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-ReceiptAdvice-2.2.xsd
@@ -439,48 +439,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Reminder-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Reminder-2.2.xsd
@@ -713,48 +713,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-RemittanceAdvice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-RemittanceAdvice-2.2.xsd
@@ -521,48 +521,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-RequestForQuotation-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-RequestForQuotation-2.2.xsd
@@ -473,48 +473,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-RetailEvent-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-RetailEvent-2.2.xsd
@@ -469,48 +469,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-SelfBilledCreditNote-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-SelfBilledCreditNote-2.2.xsd
@@ -954,48 +954,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-SelfBilledInvoice-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-SelfBilledInvoice-2.2.xsd
@@ -953,48 +953,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Statement-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Statement-2.2.xsd
@@ -554,48 +554,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-StockAvailabilityReport-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-StockAvailabilityReport-2.2.xsd
@@ -357,48 +357,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Tender-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Tender-2.2.xsd
@@ -437,48 +437,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TenderContract-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TenderContract-2.2.xsd
@@ -462,48 +462,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TenderReceipt-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TenderReceipt-2.2.xsd
@@ -352,48 +352,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TenderStatus-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TenderStatus-2.2.xsd
@@ -532,48 +532,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TenderStatusRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TenderStatusRequest-2.2.xsd
@@ -331,48 +331,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TenderWithdrawal-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TenderWithdrawal-2.2.xsd
@@ -354,48 +354,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TendererQualification-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TendererQualification-2.2.xsd
@@ -355,48 +355,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TendererQualificationResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TendererQualificationResponse-2.2.xsd
@@ -353,48 +353,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TradeItemLocationProfile-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TradeItemLocationProfile-2.2.xsd
@@ -369,48 +369,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportExecutionPlan-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportExecutionPlan-2.2.xsd
@@ -723,48 +723,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportExecutionPlanRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportExecutionPlanRequest-2.2.xsd
@@ -650,48 +650,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportProgressStatus-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportProgressStatus-2.2.xsd
@@ -350,48 +350,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportProgressStatusRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportProgressStatusRequest-2.2.xsd
@@ -299,48 +299,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportServiceDescription-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportServiceDescription-2.2.xsd
@@ -384,48 +384,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportServiceDescriptionRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportServiceDescriptionRequest-2.2.xsd
@@ -317,48 +317,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportationStatus-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportationStatus-2.2.xsd
@@ -520,48 +520,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-TransportationStatusRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-TransportationStatusRequest-2.2.xsd
@@ -438,48 +438,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-UnawardedNotification-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-UnawardedNotification-2.2.xsd
@@ -369,48 +369,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-UnsubscribeFromProcedureRequest-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-UnsubscribeFromProcedureRequest-2.2.xsd
@@ -314,48 +314,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-UnsubscribeFromProcedureResponse-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-UnsubscribeFromProcedureResponse-2.2.xsd
@@ -333,48 +333,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-UtilityStatement-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-UtilityStatement-2.2.xsd
@@ -444,48 +444,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-Waybill-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-Waybill-2.2.xsd
@@ -455,48 +455,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->

--- a/base_ubl/data/xsd-2.2/maindoc/UBL-WeightStatement-2.2.xsd
+++ b/base_ubl/data/xsd-2.2/maindoc/UBL-WeightStatement-2.2.xsd
@@ -321,48 +321,48 @@
 </xsd:schema>
 <!-- ===== Copyright Notice ===== -->
 <!--
-  OASIS takes no position regarding the validity or scope of any 
-  intellectual property or other rights that might be claimed to pertain 
-  to the implementation or use of the technology described in this 
-  document or the extent to which any license under such rights 
-  might or might not be available; neither does it represent that it has 
-  made any effort to identify any such rights. Information on OASIS's 
-  procedures with respect to rights in OASIS specifications can be 
-  found at the OASIS website. Copies of claims of rights made 
-  available for publication and any assurances of licenses to be made 
-  available, or the result of an attempt made to obtain a general 
-  license or permission for the use of such proprietary rights by 
-  implementors or users of this specification, can be obtained from 
+  OASIS takes no position regarding the validity or scope of any
+  intellectual property or other rights that might be claimed to pertain
+  to the implementation or use of the technology described in this
+  document or the extent to which any license under such rights
+  might or might not be available; neither does it represent that it has
+  made any effort to identify any such rights. Information on OASIS's
+  procedures with respect to rights in OASIS specifications can be
+  found at the OASIS website. Copies of claims of rights made
+  available for publication and any assurances of licenses to be made
+  available, or the result of an attempt made to obtain a general
+  license or permission for the use of such proprietary rights by
+  implementors or users of this specification, can be obtained from
   the OASIS Executive Director.
 
-  OASIS invites any interested party to bring to its attention any 
-  copyrights, patents or patent applications, or other proprietary 
-  rights which may cover technology that may be required to 
-  implement this specification. Please address the information to the 
+  OASIS invites any interested party to bring to its attention any
+  copyrights, patents or patent applications, or other proprietary
+  rights which may cover technology that may be required to
+  implement this specification. Please address the information to the
   OASIS Executive Director.
-  
-  This document and translations of it may be copied and furnished to 
-  others, and derivative works that comment on or otherwise explain 
-  it or assist in its implementation may be prepared, copied, 
-  published and distributed, in whole or in part, without restriction of 
-  any kind, provided that the above copyright notice and this 
-  paragraph are included on all such copies and derivative works. 
-  However, this document itself may not be modified in any way, 
-  such as by removing the copyright notice or references to OASIS, 
-  except as needed for the purpose of developing OASIS 
-  specifications, in which case the procedures for copyrights defined 
-  in the OASIS Intellectual Property Rights document must be 
-  followed, or as required to translate it into languages other than 
-  English. 
 
-  The limited permissions granted above are perpetual and will not be 
-  revoked by OASIS or its successors or assigns. 
+  This document and translations of it may be copied and furnished to
+  others, and derivative works that comment on or otherwise explain
+  it or assist in its implementation may be prepared, copied,
+  published and distributed, in whole or in part, without restriction of
+  any kind, provided that the above copyright notice and this
+  paragraph are included on all such copies and derivative works.
+  However, this document itself may not be modified in any way,
+  such as by removing the copyright notice or references to OASIS,
+  except as needed for the purpose of developing OASIS
+  specifications, in which case the procedures for copyrights defined
+  in the OASIS Intellectual Property Rights document must be
+  followed, or as required to translate it into languages other than
+  English.
 
-  This document and the information contained herein is provided on 
-  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES, 
-  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY 
-  WARRANTY THAT THE USE OF THE INFORMATION HEREIN 
-  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED 
-  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A 
-  PARTICULAR PURPOSE.    
+  The limited permissions granted above are perpetual and will not be
+  revoked by OASIS or its successors or assigns.
+
+  This document and the information contained herein is provided on
+  an "AS IS" basis and OASIS DISCLAIMS ALL WARRANTIES,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY
+  WARRANTY THAT THE USE OF THE INFORMATION HEREIN
+  WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+  WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+  PARTICULAR PURPOSE.
 -->


### PR DESCRIPTION
The linter only complains about some end of lines and end of files
chars.
Also I don't think it is a good idea to change anything in those
files.
But the only way I know about preventing the linter to access them is to
add some exclude statment in the `.pre-commit-config.yaml` file, and
I guess those changes could be overwritten during next OCA pre-commit
changes.