### PR TITLE
[FIX] account_invoice_ubl: Fix report rendintion

### DIFF
--- a/account_invoice_ubl/models/ir_actions_report.py
+++ b/account_invoice_ubl/models/ir_actions_report.py
@@ -20,11 +20,12 @@ class IrActionsReport(models.Model):
         )
         amo = self.env["account.move"]
         invoice_reports = amo._get_invoice_report_names()
+        report_name = self._get_report(report_ref).report_name
         if (
             collected_streams
             and res_ids
             and len(res_ids) == 1
-            and report_ref in invoice_reports
+            and report_name in invoice_reports
             and not self.env.context.get("no_embedded_ubl_xml")
         ):
             move = amo.browse(res_ids)


### PR DESCRIPTION
The report_ref can be one of:
    - ir.actions.report id
    - ir.actions.report record
    - ir.model.data reference to ir.actions.report
    - ir.actions.report report_name
Ensures to retrieve tne report name from a report_ref accordingly.

This will fix Warning message like this into the logs
```
WARNING odoo py.warnings: /odoo/lib/python3.11/site-packages/odoo/addons/account_invoice_ubl/models/ir_actions_report.py:27: UserWarning: unsupported operand type(s) for "==": 'ir.actions.report()' == ''account.report_invoice_with_payments''
```

ping @jbaudoux 